### PR TITLE
{Alderlake,Raptorlake}FspBinPkg: Add IoT symlink providing stable paths

### DIFF
--- a/AlderLakeFspBinPkg/IoT
+++ b/AlderLakeFspBinPkg/IoT
@@ -1,0 +1,1 @@
+Edge Platforms (Formerly known as IoT)/

--- a/RaptorLakeFspBinPkg/IoT
+++ b/RaptorLakeFspBinPkg/IoT
@@ -1,0 +1,1 @@
+Edge Platforms (Formerly known as IoT)/


### PR DESCRIPTION
Renaming the formerly known directory `IoT` breaks build systems. So, add symlinks to the new directory names in order to provide stable paths.